### PR TITLE
Redesign site with dark developer theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ My personal website, built with **React**, **Vite**, and **TypeScript**, deploye
 ### Shared Components
 
 - **`Layout`** — Wrapper with `<Outlet />` providing consistent page structure
-- **`Header`** — Name, bio, and social links
-- **`Footer`** — Site footer
+- **`Header`** — Terminal-style logo, navigation links, and social icon buttons
+- **`Footer`** — Minimal monospace centered text
 
 ### Pages
 
-- `Home.tsx` — Technical Prowess, Personality, More about me
+- `Home.tsx` — Hero section with stats, language badges, and navigation cards
 - `OpenSource.tsx` — Open source contributions
 - `BestProject.tsx` — Best project narrative
 - `Learning.tsx` — Learning activities and credentials
@@ -29,7 +29,7 @@ My personal website, built with **React**, **Vite**, and **TypeScript**, deploye
 ### Styles
 
 - CSS Modules (`*.module.css`) for component-scoped styling
-- Global theme styles in `src/styles/global.css` and `src/styles/pygment_trac.css`
+- Global theme styles in `src/styles/global.css` (dark developer theme with Space Grotesk + JetBrains Mono fonts)
 
 ## Development
 

--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -1,37 +1,34 @@
 .footer {
-  width: 640px;
+  max-width: 1000px;
   margin: 0 auto;
-  padding: 20px 0 0;
-  color: #ccc;
-  overflow: hidden;
+  padding: 32px 48px;
+  border-top: 1px solid #21262d;
+  color: #484f58;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  text-align: center;
 }
 
 .footer a {
-  color: #fff;
-  font-weight: bold;
+  color: #8b949e;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.footer a:hover {
+  color: #58a6ff;
 }
 
 .footer p {
-  float: left;
+  margin: 0;
 }
 
 .footer p + p {
-  float: right;
+  margin-top: 4px;
 }
 
 @media print, screen and (max-width: 740px) {
   .footer {
-    border-radius: 0;
-    padding: 20px;
-    width: auto;
-  }
-
-  .footer p {
-    float: none;
-    margin: 0;
-  }
-
-  .footer p + p {
-    float: none;
+    padding: 24px 20px;
   }
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,12 +4,9 @@ export default function Footer() {
   return (
     <footer className={styles.footer}>
       <p>
-        Project maintained by{" "}
-        <a href="https://github.com/JamesMGreene">JamesMGreene</a>
-      </p>
-      <p>
-        Hosted on GitHub Pages &mdash; Theme by{" "}
-        <a href="https://github.com/orderedlist">orderedlist</a>
+        © 2026{" "}
+        <a href="https://github.com/JamesMGreene">jamesmgreene</a>
+        {" "}// built with react + typescript + vite
       </p>
     </footer>
   );

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -1,19 +1,19 @@
 .header {
-  border-radius: 8px 8px 0 0;
-  background: #c6eafa;
-  background: linear-gradient(#ddfbfc, #c6eafa);
-  position: relative;
-  padding: 15px 20px;
-  border-bottom: 1px solid #b2d2e1;
+  padding: 24px 0;
+  border-bottom: 1px solid #21262d;
+  margin-bottom: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .header h1 {
   margin: 0;
   padding: 0;
-  font-size: 24px;
-  line-height: 1.2;
-  color: #069;
-  text-shadow: rgba(255, 255, 255, 0.9) 0 1px 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #58a6ff;
 }
 
 .header h1 a {
@@ -21,86 +21,77 @@
   text-decoration: none;
 }
 
+.dim {
+  color: #8b949e;
+}
+
+.header h1 .dim {
+  color: #8b949e;
+}
+
 .header p {
-  margin: 0;
-  color: #61778b;
-  width: 450px;
-  font-size: 13px;
+  display: none;
 }
 
 .header ul {
   margin: 0;
   padding: 0;
   list-style: none;
-  position: absolute;
-  z-index: 1;
-  right: 20px;
-  top: 20px;
-  height: 38px;
-  padding: 1px 0;
-  background: #5198df;
-  background: linear-gradient(#77b9fb, #3782cd);
-  border-radius: 5px;
-  box-shadow: inset rgba(255, 255, 255, 0.45) 0 1px 0,
-    inset rgba(0, 0, 0, 0.2) 0 -1px 0;
-  width: auto;
-}
-
-.header ul::before {
-  content: "";
-  position: absolute;
-  z-index: -1;
-  left: -5px;
-  top: -4px;
-  right: -5px;
-  bottom: -6px;
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 8px;
-  box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0,
-    inset rgba(255, 255, 255, 0.7) 0 -1px 0;
+  display: flex;
+  gap: 8px;
 }
 
 .header ul li {
-  width: 50px;
-  float: left;
-  border-right: 1px solid #3a7cbe;
-  height: 38px;
-}
-
-.header ul li:last-child {
-  border-right: none;
-}
-
-.header ul li + li {
-  width: 50px;
-  border-left: 1px solid #8bbef3;
+  display: inline-flex;
 }
 
 .header ul a {
-  line-height: 1;
-  font-size: 24px;
-  color: #fff;
-  color: rgba(255, 255, 255, 0.8);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 400;
-  height: 38px;
-  text-shadow: rgba(0, 0, 0, 0.4) 0 -1px 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  font-size: 1.1rem;
+  color: #8b949e;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s;
 }
 
-.header ul a strong {
-  font-size: 14px;
-  display: block;
-  color: #fff;
+.header ul a:hover {
+  background: #21262d;
+  color: #f0f6fc;
+}
+
+.nav {
+  display: flex;
+  gap: 24px;
+}
+
+.nav a {
+  color: #8b949e;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.nav a:hover {
+  color: #f0f6fc;
 }
 
 @media print, screen and (max-width: 580px) {
-  .header ul {
-    display: none;
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
   }
 
-  .header p {
-    width: 100%;
+  .nav {
+    gap: 16px;
+  }
+
+  .header ul {
+    display: none;
   }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,33 +5,20 @@ export default function Header() {
   return (
     <header className={styles.header}>
       <h1>
-        <Link to="/">James M. Greene</Link>
+        <Link to="/">jamesmgreene <span className={styles.dim}>~</span></Link>
       </h1>
-      <p>
-        JavaScript engineer/lover. Official{" "}
-        <a href="http://jquery.org/team/">jQuery team member</a>.<br />
-        Open source collaborator for{" "}
-        <a href="https://github.com/ariya/phantomjs">PhantomJS</a>,{" "}
-        <a href="https://github.com/jquery/qunit">QUnit</a>,{" "}
-        <a href="https://github.com/zeroclipboard/zeroclipboard">ZeroClipboard</a>, and{" "}
-        <a href="https://github.com/derek-watson/jsUri">jsUri</a>.
-      </p>
+      <nav className={styles.nav}>
+        <Link to="/">Home</Link>
+        <Link to="/open-source">Open Source</Link>
+        <Link to="/best-project">Best Project</Link>
+        <Link to="/learning">Learning</Link>
+      </nav>
       <ul>
         <li>
-          <a href="https://github.com/JamesMGreene">
-💻
-          </a>
-        </li>
-
-        <li>
-          <a href="https://www.linkedin.com/in/jamesmgreene/" title="LinkedIn">
-💼
-          </a>
+          <a href="https://github.com/JamesMGreene" title="GitHub">💻</a>
         </li>
         <li>
-          <Link to="/" title="Website">
-🌎
-          </Link>
+          <a href="https://www.linkedin.com/in/jamesmgreene/" title="LinkedIn">💼</a>
         </li>
       </ul>
     </header>

--- a/src/components/Layout.module.css
+++ b/src/components/Layout.module.css
@@ -1,24 +1,16 @@
 .wrapper {
-  width: 640px;
+  max-width: 1000px;
   margin: 0 auto;
-  background: #dedede;
-  border-radius: 8px;
-  box-shadow: rgba(0, 0, 0, 0.2) 0 0 0 1px, rgba(0, 0, 0, 0.45) 0 3px 10px;
+  padding: 0 48px;
 }
 
 .section {
-  padding: 15px 20px;
+  padding: 0 0 80px;
   font-size: 15px;
-  border-top: 1px solid #fff;
-  background: linear-gradient(#fafafa, #dedede 700px);
-  border-radius: 0 0 8px 8px;
-  position: relative;
 }
 
 @media print, screen and (max-width: 740px) {
   .wrapper {
-    border-radius: 0;
-    box-shadow: none;
-    width: 100%;
+    padding: 0 20px;
   }
 }

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -1,0 +1,143 @@
+.hero {
+  padding: 60px 0 48px;
+}
+
+.greeting {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9rem;
+  color: #7ee787;
+  margin-bottom: 16px;
+}
+
+.title {
+  font-size: 3rem;
+  font-weight: 700;
+  color: #f0f6fc;
+  margin-bottom: 20px;
+  line-height: 1.2;
+}
+
+.accent {
+  color: #58a6ff;
+}
+
+.bio {
+  font-size: 1.1rem;
+  color: #8b949e;
+  max-width: 600px;
+  margin-bottom: 32px;
+}
+
+.stats {
+  display: flex;
+  gap: 40px;
+  margin-bottom: 32px;
+}
+
+.stat {
+  text-align: center;
+}
+
+.number {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 2rem;
+  font-weight: 500;
+  color: #58a6ff;
+}
+
+.label {
+  font-size: 0.8rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badges {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  color: #c9d1d9;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.dotJs { background: #f1e05a; }
+.dotTs { background: #3178c6; }
+.dotReact { background: #61dafb; }
+.dotNode { background: #339933; }
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  padding: 48px 0;
+  border-top: 1px solid #21262d;
+}
+
+.card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 24px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, transform 0.2s;
+}
+
+.card:hover {
+  border-color: #58a6ff;
+  transform: translateY(-2px);
+}
+
+.card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f0f6fc;
+  margin-bottom: 8px;
+}
+
+.card p {
+  font-size: 0.85rem;
+  color: #8b949e;
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+.icon {
+  font-size: 1.5rem;
+  margin-bottom: 12px;
+}
+
+.link {
+  font-size: 0.8rem;
+  color: #58a6ff;
+}
+
+@media screen and (max-width: 740px) {
+  .title {
+    font-size: 2rem;
+  }
+
+  .stats {
+    gap: 24px;
+  }
+
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,91 +1,81 @@
 import { Link } from "react-router-dom";
+import styles from "./Home.module.css";
 
 export default function Home() {
   return (
     <>
-      <h3 id="technical-prowess">Technical Prowess</h3>
-      <ul>
-        <li>
-          I am a JavaScript language expert, for both the frontend (browsers)
-          and back (Node.js, PhantomJS, etc.). Check out my{" "}
-          <Link to="/open-source">open source work</Link> and my{" "}
-          <Link to="/best-project">best project narrative</Link> for more
-          details.
-        </li>
-        <li>
-          I am extremely proficient at learning new programming languages and
-          frameworks.
-        </li>
-        <li>
-          I am a practitioner of unit testing, though I know from experience that
-          it doesn&apos;t always pan out as well we hope.
-        </li>
-        <li>
-          I am a regular GitHub.com user but I accomplish most of my Git
-          interactions from the terminal.
-        </li>
-        <li>I am extraordinarily detail-oriented.</li>
-      </ul>
+      <section className={styles.hero}>
+        <p className={styles.greeting}>// Hello, world! 👋</p>
+        <h1 className={styles.title}>
+          I'm <span className={styles.accent}>James</span>,
+          <br />a software engineer.
+        </h1>
+        <p className={styles.bio}>
+          JavaScript expert, open source enthusiast, and builder of developer
+          tools. jQuery team member and contributor to PhantomJS, QUnit, and
+          ZeroClipboard.
+        </p>
 
-      <h3 id="personality">Personality</h3>
-      <ul>
-        <li>
-          I am an easy-going person and enjoy working with others, though I have
-          also been an &quot;individual contributor&quot; for much of my
-          professional career.
-        </li>
-        <li>
-          I have experience leading small teams (1-10 devs) on focused
-          features/refactors/projects.
-        </li>
-        <li>
-          I refuse to stop <Link to="/learning">learning</Link>, and I strive to
-          find a healthy balance between the breadth and depth of the knowledge
-          that I absorb.
-        </li>
-        <li>
-          I am very passionate about creating <em>and shipping</em> high quality
-          software; a desire which is complemented well by my detail-oriented
-          nature.
-        </li>
-        <li>
-          I am <em>obsessed</em> with the three Cs of open source:{" "}
-          <Link to="/open-source">creating, contributing, and consuming</Link>.
-        </li>
-        <li>
-          I have an unabashed love for JavaScript that most engineers consider
-          unhealthy.
-        </li>
-      </ul>
+        <div className={styles.stats}>
+          <div className={styles.stat}>
+            <div className={styles.number}>500+</div>
+            <div className={styles.label}>Repos</div>
+          </div>
+          <div className={styles.stat}>
+            <div className={styles.number}>15+</div>
+            <div className={styles.label}>Years</div>
+          </div>
+          <div className={styles.stat}>
+            <div className={styles.number}>∞</div>
+            <div className={styles.label}>Curiosity</div>
+          </div>
+        </div>
 
-      <hr />
+        <div className={styles.badges}>
+          <span className={styles.badge}>
+            <span className={`${styles.dot} ${styles.dotJs}`}></span> JavaScript
+          </span>
+          <span className={styles.badge}>
+            <span className={`${styles.dot} ${styles.dotTs}`}></span> TypeScript
+          </span>
+          <span className={styles.badge}>
+            <span className={`${styles.dot} ${styles.dotReact}`}></span> React
+          </span>
+          <span className={styles.badge}>
+            <span className={`${styles.dot} ${styles.dotNode}`}></span> Node.js
+          </span>
+        </div>
+      </section>
 
-      <h3 id="more-about-me">
-        <em>More about me!</em>
-      </h3>
-      <ul>
-        <li>
-          I{" "}
-💝{" "}
-          Open Sourcing: <Link to="/open-source">open-source</Link>
-        </li>
-        <li>
-          I{" "}
-❤️{" "}
-          Learning: <Link to="/learning">learning</Link>
-        </li>
-        <li>
-          I am very proud of a particular project:{" "}
-          <Link to="/best-project">best-project</Link>
-        </li>
-        <li>
-          I am considered a JavaScript expert by my peers and current employer
-        </li>
-        <li>
-          I may have an emoji addiction{" "}
-😊
-        </li>
-      </ul>
+      <section className={styles.cards}>
+        <Link to="/open-source" className={styles.card}>
+          <div className={styles.icon}>🚀</div>
+          <h3>Open Source</h3>
+          <p>
+            Creating, contributing, and consuming open source projects across the
+            JavaScript ecosystem.
+          </p>
+          <span className={styles.link}>Explore →</span>
+        </Link>
+        <Link to="/best-project" className={styles.card}>
+          <div className={styles.icon}>⭐</div>
+          <h3>Best Project</h3>
+          <p>
+            A deep dive into the project I'm most proud of and the challenges I
+            overcame building it.
+          </p>
+          <span className={styles.link}>Read more →</span>
+        </Link>
+        <Link to="/learning" className={styles.card}>
+          <div className={styles.icon}>📚</div>
+          <h3>Always Learning</h3>
+          <p>
+            Finding the balance between breadth and depth of knowledge across
+            languages and frameworks.
+          </p>
+          <span className={styles.link}>See what's new →</span>
+        </Link>
+      </section>
     </>
   );
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,23 +1,27 @@
-@import url(https://fonts.googleapis.com/css?family=Lato:300italic,700italic,300,700);
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
 
 html {
-  background: #6c7989;
-  background: #6c7989 linear-gradient(#6c7989, #434b55) fixed;
+  background: #0d1117;
 }
 
 body {
-  padding: 50px 0;
+  padding: 0;
   margin: 0;
-  font: 14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color: #555;
-  font-weight: 300;
-  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAeCAYAAABNChwpAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTNXG14zYAAAAUdEVYdENyZWF0aW9uIFRpbWUAMy82LzEygrTcTAAAAFRJREFUSIljfPDggZRf5RIGGNjUHsNATz6jXmSL1Kb2GLiAX+USBnrymRgGGDCORgFmoNAXjEbBaBSMRsFoFIxGwWgUjEbBaBSMRsFoFIxGwWgUAABYNujumib3wAAAAABJRU5ErkJggg==")
-    fixed;
+  font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #c9d1d9;
+  font-weight: 400;
+  line-height: 1.6;
+  background: #0d1117;
 }
 
 a {
-  color: #069;
+  color: #58a6ff;
   text-decoration: none;
+  transition: color 0.2s;
+}
+
+a:hover {
+  color: #79c0ff;
 }
 
 p {
@@ -26,8 +30,8 @@ p {
 }
 
 strong {
-  color: #222;
-  font-weight: 700;
+  color: #f0f6fc;
+  font-weight: 600;
 }
 
 h1,
@@ -36,10 +40,10 @@ h3,
 h4,
 h5,
 h6 {
-  color: #222;
+  color: #f0f6fc;
   padding: 0;
-  margin: 0 0 20px;
-  line-height: 1.2;
+  margin: 0 0 16px;
+  line-height: 1.3;
 }
 
 p,
@@ -54,31 +58,37 @@ dl {
 h1,
 h2,
 h3 {
-  line-height: 1.1;
+  line-height: 1.2;
 }
 
 h1 {
-  font-size: 28px;
+  font-size: 2rem;
 }
 
 h2 {
-  color: #393939;
+  font-size: 1.5rem;
+  color: #f0f6fc;
 }
 
 h3,
 h4,
 h5,
 h6 {
-  color: #494949;
+  color: #e6edf3;
+}
+
+h3 {
+  font-size: 1.2rem;
 }
 
 blockquote {
-  margin: 0 -20px 20px;
-  padding: 15px 20px 1px 40px;
+  margin: 0 0 20px;
+  padding: 16px 20px;
   font-style: italic;
-  background: #ccc;
-  background: rgba(0, 0, 0, 0.06);
-  color: #222;
+  background: #161b22;
+  border-left: 3px solid #58a6ff;
+  border-radius: 6px;
+  color: #8b949e;
 }
 
 img {
@@ -87,26 +97,36 @@ img {
 
 code,
 pre {
-  font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
-  color: #333;
-  font-size: 12px;
+  font-family: 'JetBrains Mono', Monaco, Consolas, monospace;
+  font-size: 13px;
   overflow-x: auto;
+}
+
+code {
+  color: #79c0ff;
+  background: #161b22;
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 
 pre {
   padding: 20px;
-  background: #3a3c42;
-  color: #f8f8f2;
-  margin: 0 -20px 20px;
+  background: #161b22;
+  color: #e6edf3;
+  margin: 0 0 20px;
+  border-radius: 8px;
+  border: 1px solid #30363d;
 }
 
 pre code {
-  color: #f8f8f2;
+  color: #e6edf3;
+  background: none;
+  padding: 0;
 }
 
 li pre {
-  margin-left: -60px;
-  padding-left: 60px;
+  margin-left: 0;
+  padding-left: 20px;
 }
 
 table {
@@ -117,28 +137,29 @@ table {
 th,
 td {
   text-align: left;
-  padding: 5px 10px;
-  border-bottom: 1px solid #aaa;
+  padding: 8px 12px;
+  border-bottom: 1px solid #21262d;
 }
 
 dt {
-  color: #222;
-  font-weight: 700;
+  color: #f0f6fc;
+  font-weight: 600;
 }
 
 th {
-  color: #222;
+  color: #f0f6fc;
 }
 
 small {
   font-size: 11px;
+  color: #8b949e;
 }
 
 hr {
   border: 0;
-  background: #aaa;
+  background: #21262d;
   height: 1px;
-  margin: 0 0 20px;
+  margin: 32px 0;
 }
 
 header,
@@ -156,6 +177,20 @@ footer {
   width: 100%;
   height: 500px;
   border: 0;
+  border-radius: 8px;
+}
+
+ul, ol {
+  padding-left: 24px;
+}
+
+li {
+  margin-bottom: 8px;
+}
+
+li ul, li ol {
+  margin-top: 8px;
+  margin-bottom: 8px;
 }
 
 @media print, screen and (max-width: 740px) {


### PR DESCRIPTION
Replace the old Jekyll Modernist-based theme with a modern dark developer aesthetic inspired by GitHub's dark mode.

## Changes
- **Fonts**: Space Grotesk + JetBrains Mono
- **Colors**: GitHub dark palette (#0d1117 background, #58a6ff accents, #7ee787 green)
- **Layout**: Full-width with max-width container, no card wrapper
- **Home page**: Hero section with stats, language badges, and 3 navigable cards
- **Header**: Terminal-style logo, inline nav links, icon buttons
- **Footer**: Minimal monospace centered text

All existing routes and content are preserved.